### PR TITLE
Sending emails to all interviewers

### DIFF
--- a/qxf2_scheduler/candidates.py
+++ b/qxf2_scheduler/candidates.py
@@ -418,6 +418,15 @@ def change_status_to_reject(candidate_id,candidate_job_applied):
     return error
 
 
+def fetch_interviewer_email(candidate_id, job_id):
+    "Fetch the interviewers email for the candidate"
+    email_id = Jobcandidate.query.filter(Jobcandidate.job_id == job_id, Jobcandidate.candidate_id == candidate_id).value(Jobcandidate.interviewer_email)
+    if email_id == None:
+        print("The interviewer is not yet assigned for the candidate")
+
+    return email_id
+
+
 @app.route("/reject", methods=["POST"])
 @login_required
 def send_reject():
@@ -426,15 +435,23 @@ def send_reject():
     candidate_email = request.form.get('candidateemail')
     candidate_job_applied = request.form.get('candidatejob')
     candidate_id = request.form.get('candidateid')
-
+    interviewer_email = fetch_interviewer_email(candidate_id, candidate_job_applied)
     logged_email = session['logged_user']
-    msg = Message("Interview update from Qxf2 Services", sender=("Qxf2 Services", "test@qxf2.com"),  cc=[logged_email], recipients=[candidate_email])
+
+    if interviewer_email == None:
+        cc = [logged_email]
+    else:
+        cc = interviewer_email.split(',')
+        cc.append(logged_email)
+
+    msg = Message("Interview update from Qxf2 Services", sender=("Qxf2 Services", "test@qxf2.com"),  cc=cc, recipients=[candidate_email])
     msg.body = "Hi %s , \n\nI appreciate your interest in a career opportunity with Qxf2 Services. It was a pleasure speaking to you about your background and interests. There are many qualified applicants in the current marketplace and we are searching for those who have the most directly applicable experience to our limited number of openings. I regret we will not be moving forward with your interview process. We wish you all the best in your current search and future endeavors.\n\nThanks, \nQxf2 Services"%(candidate_name)
     mail.send(msg)
     candidate_status = change_status_to_reject(candidate_id,candidate_job_applied)
 
     data = {'candidate_name': candidate_name, 'error': candidate_status}
     return jsonify(data)
+
 
 @app.route("/comments/save", methods=['GET', 'POST'])
 def save_comments():

--- a/qxf2_scheduler/qxf2_scheduler.py
+++ b/qxf2_scheduler/qxf2_scheduler.py
@@ -54,8 +54,8 @@ def scheduler_job():
 
 #Running the task in the background to update the jobcandidate table
 sched = BackgroundScheduler(daemon=True)
-#sched.add_job(scheduler_job,'cron', minute='*')
-sched.add_job(scheduler_job,'cron',day_of_week='mon-fri', hour='*', minute='1,31')
+sched.add_job(scheduler_job,'cron', minute='*')
+#sched.add_job(scheduler_job,'cron',day_of_week='mon-fri', hour='*', minute='1,31')
 sched.start()
 
 

--- a/qxf2_scheduler/templates/get-schedule.html
+++ b/qxf2_scheduler/templates/get-schedule.html
@@ -87,7 +87,7 @@
             // src https://stackoverflow.com/questions/21669950/jquery-ui-datpicker-excluding-weekends-mindate
             // Calculate the next working day manually
             var startDate = new Date(),
-                noOfDaysToAdd = 3,
+                noOfDaysToAdd = 0,
                 count = 1;
 
             while (count <= noOfDaysToAdd) {


### PR DESCRIPTION
In this fix we wanted to include the interviewers (whoever has handled the interview) email to send invite/reject email.

Files changed are:
1.routes.py
2.candidates.py
Files for scheduling and cron job update
3.qxf2_scheduler.py
4.get-schedule.html
These 3&4 I will rever it back.

What changes:
1. You can see all the interviewers email id in the job-candidate-page
2.Invite email/reject email will be sent to the interviewers.

